### PR TITLE
patch: fix crashes when token has no DMs access

### DIFF
--- a/BlueWP/Inlays/ConvoListInlay.xaml.cs
+++ b/BlueWP/Inlays/ConvoListInlay.xaml.cs
@@ -39,7 +39,7 @@ namespace BlueWP.Inlays
       var response = await _mainPage.Get<ATProto.Lexicons.Chat.BSky.Convo.ListConvos.Response>(new ATProto.Lexicons.Chat.BSky.Convo.ListConvos()
       {
       });
-      if (response != null)
+      if (response != null && response.convos != null)
       {
         Convos = response.convos.Select(s => new Convo() {
           ConvoView = s,

--- a/BlueWP/Pages/MainPage.xaml.cs
+++ b/BlueWP/Pages/MainPage.xaml.cs
@@ -159,7 +159,7 @@ namespace BlueWP.Pages
       var convoUnreadCountResponse = await Get<ATProto.Lexicons.Chat.BSky.Convo.ListConvos.Response>(new ATProto.Lexicons.Chat.BSky.Convo.ListConvos() {
         limit = 1
       });
-      if (convoUnreadCountResponse != null)
+      if (convoUnreadCountResponse != null && convoUnreadCountResponse.convos != null)
       {
         UnreadConvoNotificationCount = convoUnreadCountResponse.convos.Sum(s => s.unreadCount);
       }


### PR DESCRIPTION
The app was crashing for me because I didn't give the app password access to my DMs, this should fix it.